### PR TITLE
Backport some changes from npm actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:10-slim
+FROM node:10
 
-LABEL version="1.0.0"
+LABEL version="1.1.0"
 LABEL repository="https://github.com/Borales/actions-yarn"
 LABEL homepage="https://github.com/Borales/actions-yarn"
 LABEL maintainer="Oleksandr Bordun <bordun.alexandr@gmail.com>"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,9 +6,16 @@ if [ -n "$NPM_AUTH_TOKEN" ]; then
   # Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
   NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
   NPM_REGISTRY_URL="${NPM_REGISTRY_URL-registry.npmjs.org}"
+  NPM_STRICT_SSL="${NPM_STRICT_SSL-true}"
+  NPM_REGISTRY_SCHEME="https"
+  if ! $NPM_STRICT_SSL
+  then
+    NPM_REGISTRY_SCHEME="http"
+  fi
 
   # Allow registry.npmjs.org to be overridden with an environment variable
-  printf "//%s/:_authToken=%s\\nregistry=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
+  printf "//%s/:_authToken=%s\\nregistry=%s\\nstrict-ssl=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "${NPM_REGISTRY_SCHEME}://$NPM_REGISTRY_URL" "${NPM_STRICT_SSL}" > "$NPM_CONFIG_USERCONFIG"
+
   chmod 0600 "$NPM_CONFIG_USERCONFIG"
 fi
 


### PR DESCRIPTION
I updated two things:

- The entrypoint.sh script which seems to add some config options (not sure its relevant with yarn)
- Dockerfile now uses the full node image (more at https://github.com/actions/npm/issues/8)

I also dumped the version because of it