### PR TITLE
fix .npmrc file generation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,9 +4,9 @@ set -e
 
 if [ -n "$NPM_AUTH_TOKEN" ]; then
   # Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
-  NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
-  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-registry.npmjs.org}"
-  NPM_STRICT_SSL="${NPM_STRICT_SSL-true}"
+  NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG:-"$HOME/.npmrc"}"
+  NPM_REGISTRY_URL="${NPM_REGISTRY_URL:-registry.npmjs.org}"
+  NPM_STRICT_SSL="${NPM_STRICT_SSL:-true}"
   NPM_REGISTRY_SCHEME="https"
   if ! $NPM_STRICT_SSL
   then


### PR DESCRIPTION
When we pass an `auth-token`, a `.npmrc` file is generated but it's value could be invalid
The parameter substitution to set a default value on `NPM_` was not working.

Github action defines the `NPM_*` environment variables with a null value, but we were setting a default value only if the environment variable was not set at all.