### PR TITLE
Install prerequites for native modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine
 
-RUN apk add --no-cache git python2 g++ make
+RUN apk add --no-cache git python2 build-base
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine
 
-RUN apk add --no-cache git python2
+RUN apk add --no-cache git python2 g++ make
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine
 
-RUN apk add --no-cache git
+RUN apk add --no-cache git python2
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["help"]


### PR DESCRIPTION
 * node-gyp cannot run without the ability to build packages
 * node-gyp also has a prerequisite on python
 required for compiling any module that has C++ bindings.

https://github.com/nodejs/node-gyp