### PR TITLE
Update python2 to python3 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine
 
-RUN apk add --no-cache git python2 build-base
+RUN apk add --no-cache git python3 build-base
 RUN npm i -g --force yarn
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Since alpine LTS 3.16, python2 has been removed. Bumping to python3 .

From [3.16 release notes](https://alpinelinux.org/posts/Alpine-3.16.0-released.html):
<img width="268" alt="image" src="https://user-images.githubusercontent.com/44983719/172528374-85f5ff67-48b4-4fa6-b1cc-dd41986c4713.png">
